### PR TITLE
Change repository due to docker rate limitations

### DIFF
--- a/.pendingremake/lazylibrarian.yml
+++ b/.pendingremake/lazylibrarian.yml
@@ -15,7 +15,7 @@
         pgrole: 'lazylibrarian'
         intport: '5299'
         extport: '5299'
-        image: 'linuxserver/lazylibrarian'
+        image: 'ghcr.io/linuxserver/lazylibrarian'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/.pendingremake/qbittorrent.yml
+++ b/.pendingremake/qbittorrent.yml
@@ -16,7 +16,7 @@
         pgrole: 'qbittorrent'
         intport: '8080'
         extport: '8083'
-        image: 'linuxserver/qbittorrent'
+        image: 'ghcr.io/linuxserver/qbittorrent'
 
     # CORE (MANDATORY) #############################################################
     - name: 'Including cron job'

--- a/.pendingremake/rutorrent.yml
+++ b/.pendingremake/rutorrent.yml
@@ -19,7 +19,7 @@
         extport2: '5000'
         intport3: '51413'
         extport3: '51413'
-        image: 'linuxserver/rutorrent'
+        image: 'ghcr.io/linuxserver/rutorrent'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/.template_new
+++ b/.template_new
@@ -28,8 +28,8 @@ container_permissions PGID 1000
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 # how users select an image; the 1st image is the default. If only 1, it's ok!
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/nzbget:latest
-linuxserver/nzbget:testing
+ghcr.io/linuxserver/nzbget:latest
+ghcr.io/linuxserver/nzbget:testing
 EOF
 
 # YML EXPORT ###################################################################

--- a/emby
+++ b/emby
@@ -19,8 +19,8 @@ container_permissions PGID 1000
 container_permissions GIDLIST 1000
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/emby:latest
-linuxserver/emby:beta
+ghcr.io/linuxserver/emby:latest
+ghcr.io/linuxserver/emby:beta
 EOF
 # YML EXPORT ###################################################################
 container_core

--- a/jackett
+++ b/jackett
@@ -5,7 +5,7 @@ jackett () {
 container_reset
 # VARIABLES ####################################################################
 pgrole="jackett"
-image="linuxserver/jackett"
+image="ghcr.io/linuxserver/jackett"
 port_inside01="9117"
 port_outside01="9117"
 traefik_extport="9117"
@@ -19,8 +19,8 @@ container_permissions GID 1000
 container_permissions GIDLIST 1000
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/jackett:latest
-linuxserver/jackett:development
+ghcr.io/linuxserver/jackett:latest
+ghcr.io/linuxserver/jackett:development
 EOF
 # YML EXPORT ###################################################################
 container_core

--- a/jellyfin
+++ b/jellyfin
@@ -19,8 +19,8 @@ container_permissions GID 1000
 container_permissions GIDLIST 1000
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/jellyfin:latest
-linuxserver/jellyfin:nightly
+ghcr.io/linuxserver/jellyfin:latest
+ghcr.io/linuxserver/jellyfin:nightly
 EOF
 # YML EXPORT ###################################################################
 container_core

--- a/lidarr
+++ b/lidarr
@@ -5,7 +5,7 @@ lidarr () {
 container_reset
 # VARIABLES ####################################################################
 pgrole="lidarr"
-image="linuxserver/lidarr"
+image="ghcr.io/linuxserver/lidarr"
 port_inside01="8686"
 port_outside01="8686"
 traefik_extport="8686"
@@ -19,8 +19,8 @@ container_permissions PUID 1000
 container_permissions PGID 1000
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/lidarr:preview
-linuxserver/lidarr:latest
+ghcr.io/linuxserver/lidarr:preview
+ghcr.io/linuxserver/lidarr:latest
 EOF
 # YML EXPORT ###################################################################
 container_core

--- a/nzbget
+++ b/nzbget
@@ -23,8 +23,8 @@ container_permissions PGID 1000
 container_permissions LC_ALL C
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/nzbget:latest
-linuxserver/nzbget:testing
+ghcr.io/linuxserver/nzbget:latest
+ghcr.io/linuxserver/nzbget:testing
 EOF
 # YML EXPORT ###################################################################
 container_core

--- a/nzbhydra2
+++ b/nzbhydra2
@@ -17,8 +17,8 @@ container_permissions PUID 1000
 container_permissions PGID 1000
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/nzbhydra2:latest
-linuxserver/nzbhydra2:dev
+ghcr.io/linuxserver/nzbhydra2:latest
+ghcr.io/linuxserver/nzbhydra2:dev
 EOF
 # YML EXPORT ###################################################################
 container_core

--- a/ombi
+++ b/ombi
@@ -17,8 +17,8 @@ container_permissions PUID 1000
 container_permissions PGID 1000
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/ombi:latest
-linuxserver/ombi:development
+ghcr.io/linuxserver/ombi:latest
+ghcr.io/linuxserver/ombi:development
 EOF
 # YML EXPORT ###################################################################
 container_core

--- a/plex
+++ b/plex
@@ -50,13 +50,13 @@ fi
 container_oddball etc_hosts "{ 'analytics.plex.tv': '127.0.0.1', 'metrics.plex.tv': '127.0.0.1' }"
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/tautulli latest
-linuxserver/tautulli develop
+ghcr.io/linuxserver/tautulli latest
+ghcr.io/linuxserver/tautulli develop
 EOF
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/plex:latest
-linuxserver/plex:public
+ghcr.io/linuxserver/plex:latest
+ghcr.io/linuxserver/plex:public
 plexinc/pms-docker:latest
 plexinc/pms-docker:plexpass
 plexinc/pms-docker:public

--- a/radarr
+++ b/radarr
@@ -19,9 +19,9 @@ container_permissions PGID 1000
 
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/radarr:preview
-linuxserver/radarr:nightly
-linuxserver/radarr:latest
+ghcr.io/linuxserver/radarr:preview
+ghcr.io/linuxserver/radarr:nightly
+ghcr.io/linuxserver/radarr:latest
 EOF
 # YML EXPORT ###################################################################
 container_core

--- a/sabnzbd
+++ b/sabnzbd
@@ -25,8 +25,8 @@ common_main /pg/data/sabnzbd/cname.traefik sabnzbd sab_sub
 common_main /pg/var/traefik/t.domain NOT-SET sab_domain
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/sabnzbd:latest
-linuxserver/sabnzbd:unstable
+ghcr.io/linuxserver/sabnzbd:latest
+ghcr.io/linuxserver/sabnzbd:unstable
 EOF
 # YML EXPORT ###################################################################
 container_core

--- a/sonarr
+++ b/sonarr
@@ -18,9 +18,9 @@ container_permissions PUID 1000
 container_permissions PGID 1000
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/sonarr:preview
-linuxserver/sonarr:nightly
-linuxserver/sonarr:latest
+ghcr.io/linuxserver/sonarr:preview
+ghcr.io/linuxserver/sonarr:nightly
+ghcr.io/linuxserver/sonarr:latest
 EOF
 # YML EXPORT ###################################################################
 container_core

--- a/tautulli
+++ b/tautulli
@@ -21,8 +21,8 @@ container_permissions TZ Europe/London
 mkdir -p "/pg/data/plex/database/Library/Application Support/Plex Media Server/Logs"
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/tautulli:latest
-linuxserver/tautulli:develop
+ghcr.io/linuxserver/tautulli:latest
+ghcr.io/linuxserver/tautulli:develop
 EOF
 # YML EXPORT ###################################################################
 container_core


### PR DESCRIPTION
Changed linuxserver.io repository to the ghcr.io prefix per the linuxserver.io team due to the rate limits now being imposed by docker.com